### PR TITLE
Add S3/AWS utilities

### DIFF
--- a/cmd/s3-copy/main.go
+++ b/cmd/s3-copy/main.go
@@ -1,0 +1,91 @@
+// s3-copy copies an S3 file from one bucket to another.
+//
+// Example usage:
+//
+//     s3-copy --from=akey.csv --from-bucket=stagebucket --from-profile=stage \
+//          --from-region=us-west-1 --to-bucket=prodbucket --to-profile=prod
+//
+// It achieves this by using one set of credentials to download the file to your
+// machine, then (optionally) a different set of credentials or regions to
+// upload the file.
+//
+// Due to the limitations of the aws-sdk-go library, the entire file is
+// currently downloaded and read into memory before being uploaded again.
+//
+// Credentials are read out of your environment using `aws-vault`. This is
+// designed to be run on a local machine.
+//
+// To call this function from another Go program, use the S3Copier interface in
+// github.com/segmentio/go-utils.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	utils "github.com/segmentio/go-utils"
+)
+
+func checkError(err error, reason string) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error %s: %v\n", reason, err)
+		os.Exit(2)
+	}
+}
+
+func main() {
+	profile := flag.String("profile", "", "Profile to use for get and put. Cannot use with -to-profile or -from-profile")
+	from := flag.String("from", "", "S3 file to get")
+	fromBucket := flag.String("from-bucket", "", "S3 bucket to get object from")
+	fromProfile := flag.String("from-profile", "", "Profile to use to fetch")
+	fromRegion := flag.String("from-region", "", "Region to use for fetch (defaults to value in profile)")
+
+	to := flag.String("to", "", "S3 file to put (defaults to the Key for from)")
+	toBucket := flag.String("to-bucket", "", "S3 bucket to put object")
+	toProfile := flag.String("to-profile", "", "Profile to use for put object")
+	toRegion := flag.String("to-region", "", "Region to use for put (defaults to value in profile)")
+
+	acl := flag.String("acl", "", "ACL to use for putting the object")
+	timeout := flag.Duration("timeout", utils.DefaultS3Timeout, "Amount of time to allow for the operation")
+	flag.Parse()
+	if *profile != "" {
+		if *toProfile != "" || *fromProfile != "" {
+			os.Stderr.WriteString("Cannot set -profile and (-to-profile or -from-profile)\n")
+			os.Exit(2)
+		}
+		*toProfile = *profile
+		*fromProfile = *profile
+	}
+	// TODO: check whether from contains a s3:// URL, and get the from bucket
+	// from that if so.
+	if *fromBucket == "" {
+		os.Stderr.WriteString("Please provide a from bucket\n")
+		os.Exit(2)
+	}
+	if *from == "" {
+		os.Stderr.WriteString("Please provide a from argument\n")
+		os.Exit(2)
+	}
+	copier := &utils.S3Copier{
+		FromProfile: *fromProfile,
+		ToProfile:   *toProfile,
+		Timeout:     *timeout,
+	}
+	if *to == "" {
+		*to = *from
+	}
+	settings := &utils.S3CopySettings{
+		FromKey:    *from,
+		FromBucket: *fromBucket,
+		ToKey:      *to,
+		ToBucket:   *toBucket,
+		FromRegion: *fromRegion,
+		ToRegion:   *toRegion,
+		ACL:        *acl,
+	}
+	if err := copier.Copy(settings); err != nil {
+		fmt.Fprintf(os.Stderr, err.Error()+"\n")
+		os.Exit(2)
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,17 @@
+package utils_test
+
+import (
+	"fmt"
+
+	utils "github.com/segmentio/go-utils"
+)
+
+func ExampleS3Copier() {
+	copier := utils.NewS3Copier("stageprofile", "prodprofile")
+	err := copier.Copy(&utils.S3CopySettings{
+		FromKey:    "foo-bar.csv",
+		FromBucket: "stagebucket",
+		ToBucket:   "prodbucket",
+	})
+	fmt.Println(err)
+}

--- a/s3.go
+++ b/s3.go
@@ -1,0 +1,119 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/segmentio/go-utils/session"
+)
+
+// An S3Copier copies files from one S3 profile to another.
+type S3Copier struct {
+	FromProfile string
+	ToProfile   string
+	Timeout     time.Duration
+}
+
+// S3CopySettings are used to copy a single object from one bucket to another.
+type S3CopySettings struct {
+	// Key to retrieve the object.
+	FromKey    string
+	FromBucket string
+	// Key to put the object to. If empty, uses settings.FromKey.
+	ToKey    string
+	ToBucket string
+	// Region to get the object from. If empty, uses the region from the
+	// FromProfile.
+	FromRegion string
+	// Region to put the object to. If empty, uses the region from the
+	// ToProfile.
+	ToRegion string
+	// ACL to use for putting the object.
+	ACL string
+}
+
+// DefaultS3Timeout is the default timeout for an S3 copy to complete.
+var DefaultS3Timeout = 10 * time.Minute
+
+// NewS3Copier creates an S3Copier for copying objects between profiles.
+//
+// More configuration options can be set by directly initializing an S3Copier.
+func NewS3Copier(fromProfile, toProfile string) *S3Copier {
+	return &S3Copier{
+		FromProfile: fromProfile,
+		ToProfile:   toProfile,
+		Timeout:     DefaultS3Timeout,
+	}
+}
+
+func wrap(err error, reason string) error {
+	return fmt.Errorf("Error %s: %v", reason, err)
+}
+
+// Copy copies the object from settings.FromBucket to settings.ToBucket using
+// the given credentials, and returns an error if any exist.
+//
+// Copy will ask aws-vault to return valid credentials for s.FromProfile and
+// s.ToProfile.
+func (s *S3Copier) Copy(settings *S3CopySettings) error {
+	c := &session.CredentialGetter{
+		Region: settings.FromRegion,
+	}
+	sess, err := c.Get(s.FromProfile, nil)
+	if err != nil {
+		return wrap(err, "getting credentials")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), s.Timeout)
+	defer cancel()
+	svc := s3.New(sess)
+	inp := new(s3.GetObjectInput)
+	inp.SetBucket(settings.FromBucket)
+	inp.SetKey(settings.FromKey)
+	req, out := svc.GetObjectRequest(inp)
+	req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
+	if err := req.Send(); err != nil {
+		return wrap(err, "getting object")
+	}
+	fmt.Fprintf(os.Stderr, "downloading s3://%s/%s\n", settings.FromBucket, settings.FromKey)
+	// Not happy about this, but the PutObjectInput.Body needs to be
+	// a ReadSeeker, so we need to buffer everything.
+	body, err := ioutil.ReadAll(out.Body)
+	if err != nil {
+		return wrap(err, "downloading object")
+	}
+	if err := out.Body.Close(); err != nil {
+		return wrap(err, "closing get request body")
+	}
+
+	putc := &session.CredentialGetter{
+		Region: settings.ToRegion,
+	}
+	sess2, err := putc.Get(s.ToProfile, nil)
+	if err != nil {
+		return wrap(err, "getting credentials for put request")
+	}
+	svc2 := s3.New(sess2)
+	inp2 := new(s3.PutObjectInput)
+	inp2.SetBucket(settings.ToBucket)
+	if settings.ToKey == "" {
+		inp2.SetKey(settings.FromKey)
+	} else {
+		inp2.SetKey(settings.ToKey)
+	}
+	inp2.SetBody(bytes.NewReader(body))
+	inp2.SetACL(settings.ACL)
+	req2, _ := svc2.PutObjectRequest(inp2)
+	req2.HTTPRequest = req2.HTTPRequest.WithContext(ctx)
+	fmt.Fprintf(os.Stderr, "uploading s3://%s/%s\n", *inp2.Bucket, *inp2.Key)
+	start := time.Now()
+	if err := req2.Send(); err != nil {
+		return wrap(err, "putting object")
+	}
+	fmt.Fprintf(os.Stderr, "upload completed in %v\n", time.Since(start))
+	return nil
+}

--- a/session/example_test.go
+++ b/session/example_test.go
@@ -1,0 +1,16 @@
+package session_test
+
+import (
+	"fmt"
+
+	"github.com/segmentio/go-utils/session"
+)
+
+func ExampleGet() {
+	sess, err := session.Get("stage", nil)
+	if err != nil {
+		fmt.Print(err)
+		return
+	}
+	fmt.Println(sess.Config.Region)
+}

--- a/session/session.go
+++ b/session/session.go
@@ -1,0 +1,86 @@
+package session
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+// A CredentialGetter is used to get valid (temporary) AWS credentials.
+type CredentialGetter struct {
+	Region string // Region to use; if unset, defaults to region in profile.
+}
+
+var DefaultCredentialGetter = &CredentialGetter{}
+
+// Get returns a valid aws session.Session for the given realm. Get reads MFA
+// tokens from in; if in is nil, os.Stdin will be used.
+//
+// The region for the request should be specified in the profile config file.
+func Get(realm string, in io.Reader) (*session.Session, error) {
+	return DefaultCredentialGetter.Get(realm, in)
+}
+
+// Get returns a valid aws session.Session for the given realm. Get reads MFA
+// tokens from in; if in is nil, os.Stdin will be used.
+//
+// Get is designed for local access - getting credentials on your local machine.
+func (c *CredentialGetter) Get(realm string, in io.Reader) (*session.Session, error) {
+	// aws-vault does not have good API's for programmatic access; a lot of the
+	// code we need is buried inside 'package main'. instead, hack
+	//
+	// in addition I couldn't figure out a way to print exactly 4 environment
+	// variables, so just print all of them and filter the ones we need.
+	//
+	// also TODO: figure out the right realm to use on everyone's machines.
+	cmd := exec.Command("aws-vault", "exec", realm, "env")
+	if in == nil {
+		in = os.Stdin
+	}
+	cmd.Stdin = in
+	// MFA prompt gets printed here
+	cmd.Stderr = os.Stderr
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	if err := cmd.Run(); err != nil {
+		io.Copy(os.Stdout, &buf)
+		return nil, err
+	}
+	scanner := bufio.NewScanner(&buf)
+	var key, secret, token, region string
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		switch parts[0] {
+		case "AWS_ACCESS_KEY_ID":
+			key = parts[1]
+		case "AWS_SECRET_ACCESS_KEY":
+			secret = parts[1]
+		case "AWS_SESSION_TOKEN":
+			token = parts[1]
+		case "AWS_REGION":
+			region = parts[1]
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if c.Region != "" {
+		region = c.Region
+	}
+	creds := credentials.NewStaticCredentials(key, secret, token)
+	return session.NewSession(&aws.Config{
+		Region:      aws.String(region),
+		Credentials: creds,
+	})
+}


### PR DESCRIPTION
Add a function for populating an aws.Session from aws-vault, and a
command that lets you copy an S3 file between buckets, potentially
existing in different regions/requiring different profiles to access.